### PR TITLE
Allow any identifier to be a flail chain

### DIFF
--- a/flail/__init__.py
+++ b/flail/__init__.py
@@ -1,4 +1,24 @@
 # flail/__init__.py
+"""
+Flail - Decorators with more injuries
+
+Flail allows any decorator to be transformed into something that looks a little
+bit like a ball-and-chain attached to the thing that's being decorated.
+
+Example:
+    >>> from flail import _
+    >>> _.d = lambda x: x
+    >>> @_.__.__.__.d
+    >>> def my_fabulous_method():
+    >>>      ...
+
+Example:
+    >>> from flail import 𞸁
+    >>> 𞸁.d = lambda x: x
+    >>> @𞸁.ﺻﺻﺻﺻﺻﺻﺻﺻ.d
+    >>> def my_fabulous_method():
+    >>>      ...
+"""
 
 __all__ = ['_']
 
@@ -7,6 +27,8 @@ __version__ = '0.1.0'
 _ = type('',(),dict(__getattr__=lambda s,_:s))()
 
 
-
-
-
+def __getattr__(name):
+    """
+    Allows any identifier to be the chain of the flail
+    """
+    return _

--- a/flail/__init__.py
+++ b/flail/__init__.py
@@ -2,11 +2,11 @@
 
 __all__ = ['_']
 
+__version__ = '0.1.0'
+
 _ = type('',(),dict(__getattr__=lambda s,_:s))()
 
-        
 
-    
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,40 @@ try:
 except ImportError:
     from distutils.core import setup
 
+
+def parse_version(fpath):
+    """
+    Statically parse the version number from a python file
+    """
+    import ast
+    import os
+    if not os.path.exists(fpath):
+        raise ValueError('fpath={!r} does not exist'.format(fpath))
+    with open(fpath, 'r') as file_:
+        sourcecode = file_.read()
+    pt = ast.parse(sourcecode)
+    class Finished(Exception):
+        pass
+    class VersionVisitor(ast.NodeVisitor):
+        def visit_Assign(self, node):
+            for target in node.targets:
+                if getattr(target, 'id', None) == '__version__':
+                    self.version = node.value.s
+                    raise Finished
+    visitor = VersionVisitor()
+    try:
+        visitor.visit(pt)
+    except Finished:
+        pass
+    return visitor.version
+
 setup(name = "flail",
             description="Flail - The Ball and Chain Decorator",
             long_description = """
 Decorators with more injuries
 """,
             license="""MIT""",
-            version = "0.0",
+            version = parse_version('flail/__init__.py'),
             author = "David Beazley",
             author_email = "dave@dabeaz.com",
             maintainer = "David Beazley",


### PR DESCRIPTION
Fixes #2.

I realized a much easier approach than enumerating valid flail connectors would be just to allow anything to be used as a flail. With Python 3.7 this is possible via PEP 562: https://www.python.org/dev/peps/pep-0562/. A module level `__getattr__` redirects all undefined names to the base of the flail.

I also added docstrings and doctests, because [I'm into that](https://github.com/Erotemic/xdoctest).